### PR TITLE
Move /ingest to new Beam serverless endpoint

### DIFF
--- a/.beamignore
+++ b/.beamignore
@@ -1,0 +1,7 @@
+.venv
+venv
+.idea
+.vscode
+.git
+*.pyc
+__pycache__

--- a/src/api/crawlee.ts
+++ b/src/api/crawlee.ts
@@ -68,19 +68,50 @@ export async function crawl(config: Config) {
 
             // Asynchronously call the ingestWebscrape endpoint without awaiting the result
             if (html) {
-              ingestionPromises.push(
-                axios.post('https://flask-production-751b.up.railway.app/ingest-web-text', {
+
+              // success_fail = ingester.ingest_single_web_text(course_name, base_url, url, content, title)
+
+              fetch("https://41kgx.apps.beam.cloud", {
+                "method": "POST",
+                "headers": {
+                  "Accept": "*/*",
+                  "Accept-Encoding": "gzip, deflate",
+                  "Authorization": "Basic NTdjMGEwNDgxNjNhOTlmODY2NGZmNmM1ZGRhNzA4Yjk6NTBiZDJiM2M2YjgwMWFmZjRjMmRmODk5ZDAzNTUwMjg=",
+                  "Content-Type": "application/json"
+                },
+                "body": JSON.stringify({
                   base_url: config.url,
                   url: request.loadedUrl,
-                  title: title,
+                  readable_filename: title,
                   content: html,
-                  courseName: config.courseName,
-                }).then(() => {
-                  console.log(`Data ingested for URL: ${request.loadedUrl}`);
-                }).catch(error => {
-                  console.error(`Failed to ingest data for URL: ${request.loadedUrl}`, error.name, error.message, error.data);
+                  course_name: config.courseName,
+                  // s3_paths: s3Key,
                 })
-              )
+              })
+                .then(response => response.text())
+                .then(text => {
+                  console.log(`In success case -- Data ingested for URL: ${request.loadedUrl}`);
+                  console.log(text)
+                })
+                .catch(err => console.error(err));
+
+
+
+              // ingestionPromises.push(
+              //   axios.post('https://flask-production-751b.up.railway.app/ingest-web-text', {
+              //     base_url: config.url,
+              //     url: request.loadedUrl,
+              //     title: title,
+              //     content: html,
+              //     courseName: config.courseName,
+              //   }).then(() => {
+              //     console.log(`Data ingested for URL: ${request.loadedUrl}`);
+              //   }).catch(error => {
+              //     console.error(`Failed to ingest data for URL: ${request.loadedUrl}`, error.name, error.message, error.data);
+              //   })
+              // )
+
+
             }
           } else {
             console.error('Error: URL is undefined. Title is: ', title);

--- a/src/api/crawlee.ts
+++ b/src/api/crawlee.ts
@@ -76,7 +76,7 @@ export async function crawl(config: Config) {
                 "headers": {
                   "Accept": "*/*",
                   "Accept-Encoding": "gzip, deflate",
-                  "Authorization": "Basic NTdjMGEwNDgxNjNhOTlmODY2NGZmNmM1ZGRhNzA4Yjk6NTBiZDJiM2M2YjgwMWFmZjRjMmRmODk5ZDAzNTUwMjg=",
+                  "Authorization": `Basic ${process.env.BEAM_API_KEY}`,
                   "Content-Type": "application/json"
                 },
                 "body": JSON.stringify({

--- a/src/api/uploadToS3.ts
+++ b/src/api/uploadToS3.ts
@@ -39,20 +39,45 @@ export async function uploadPdfToS3(url: string, courseName: string) {
 }
 
 export async function ingestPdf(s3Key: string, courseName: string, base_url: string, url: string) {
-  const ingestEndpoint = 'https://flask-production-751b.up.railway.app/ingest';
-  const readableFilename = path.basename(s3Key);
-  try {
-    const response = await axios.get(ingestEndpoint, {
-      params: {
-        course_name: courseName,
-        s3_paths: s3Key,
-        readable_filename: readableFilename,
-        url: url,
-        base_url: base_url,
-      },
-    });
-    console.log(`PDF ingested:`, response.data);
-  } catch (error) {
-    console.error(`Error ingesting PDF: ${error}`);
-  }
+
+  fetch("https://41kgx.apps.beam.cloud", {
+    "method": "POST",
+    "headers": {
+      "Accept": "*/*",
+      "Accept-Encoding": "gzip, deflate",
+      "Authorization": `Basic ${process.env.BEAM_API_KEY}`,
+      "Content-Type": "application/json"
+    },
+    "body": JSON.stringify({
+      base_url: base_url,
+      url: url,
+      readable_filename: path.basename(s3Key),
+      s3_paths: s3Key,
+      course_name: courseName,
+    })
+  })
+    .then(response => response.text())
+    .then(text => {
+      console.log(`In success case -- Data ingested for pdf: ${path.basename(s3Key)}`);
+      console.log(text)
+    })
+    .catch(err => console.error(err));
+
+
+  // const ingestEndpoint = 'https://flask-production-751b.up.railway.app/ingest';
+  // const readableFilename = path.basename(s3Key);
+  // try {
+  //   const response = await axios.get(ingestEndpoint, {
+  //     params: {
+  //       course_name: courseName,
+  //       s3_paths: s3Key,
+  //       readable_filename: readableFilename,
+  //       url: url,
+  //       base_url: base_url,
+  //     },
+  //   });
+  //   console.log(`PDF ingested:`, response.data);
+  // } catch (error) {
+  //   console.error(`Error ingesting PDF: ${error}`);
+  // }
 }


### PR DESCRIPTION
This should allow our ingest to keep up with web scrape, and have a nice task queue implementation so we don't overload any part of our system. Yay for concurrency control and great dev tools!