### PR TITLE
add health check endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,9 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# IDE
+.idea
+
+# MacOS
+.DS_Store

--- a/src/api/health.ts
+++ b/src/api/health.ts
@@ -3,7 +3,7 @@ import { Request, Response, Router } from 'express';
 
 const router = Router();
 
-router.get('/health', (req: Request, res: Response) => {
+router.get('/health', (_: Request, res: Response) => {
   res.status(200).json({
     status: 'ok',
     timestamp: new Date().toISOString(),

--- a/src/api/health.ts
+++ b/src/api/health.ts
@@ -1,0 +1,13 @@
+// src/api/health.ts
+import { Request, Response, Router } from 'express';
+
+const router = Router();
+
+router.get('/health', (req: Request, res: Response) => {
+  res.status(200).json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+  });
+});
+
+export default router;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 // uploadToS3.ts
 import express, { Request, Response } from 'express';
 import { crawl } from './api/crawlee.js';
+import healthRoute from './api/health.js'; // Import your health route
+
 import cors from 'cors';
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
@@ -57,6 +59,9 @@ app.post('/crawl', async (req: Request, res: Response) => {
         }
     }
 });
+
+// add a health check route
+app.use('/api', healthRoute); // GET /api/health
 
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
I would need a health check endpoint for the AWS load balancer as well as for debugging purpose. 
Added GET /api/health which prints: `{"status":"ok","timestamp":"2025-06-09T19:38:30.462Z"}`